### PR TITLE
Added demo to JSFiddle and additional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 This plugin autocompletes email addresses when supplied with an email domain.  Instead of the regular JQuery autocomplete's dropdown menu of autocomplete suggestions, this types ahead while keeping the auto-filled text highlighted as to not obstruct the user.
 
+### Demo
+
+http://jsfiddle.net/MauH7/
+
 ## To use this plugin, download the file and on pageload, call:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ http://jsfiddle.net/MauH7/
 ## To use this plugin, download the file and on pageload, call:
 
 ```javascript
-$('#your-field').autoEmail("yourdomain.com");
+$('#your-field').autoEmail("yourdomain.com", false);
 ```
+
+`domain` is the domain to use. `multi` is a boolean that allows or disallows the user to append multiple emails separated by a `,` or `:`.
 
 ##### This is in early development, so it's not perfect.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ http://jsfiddle.net/MauH7/
 $('#your-field').autoEmail("yourdomain.com", false);
 ```
 
-`domain` is the domain to use. `multi` is a boolean that allows or disallows the user to append multiple emails separated by a `,` or `:`.
+The method accepts two parameters, `domain` and `multi-enabled`.
 
-##### This is in early development, so it's not perfect.
+* `domain` is the domain to use for autocompletion
+* `multi-enabled` is a boolean flag that enables the user to enter multiple emails in the field, separated by a `,` or `;`

--- a/auto-email.jquery.json
+++ b/auto-email.jquery.json
@@ -1,0 +1,24 @@
+{
+    "name": "auto-email",
+    "title": "Auto-Email",
+    "description": "jQuery plugin for autocompleting email fields.",
+    "keywords": [
+        "autocomplete",
+        "email"
+    ],
+    "version": "0.1.0",
+    "author": {
+        "name": "Chris Yuska and other contributors",
+    },
+    "licenses": [
+        {
+            "type": "MIT",
+            "url": "https://github.com/chrisyuska/auto-email/blob/master/License.md"
+        }
+    ],
+    "bugs": "https://github.com/chrisyuska/auto-email/issues",
+    "homepage": "https://github.com/chrisyuska/auto-email",
+    "dependencies": {
+        "jquery": ">=1.5"
+    }
+}

--- a/auto-email.js
+++ b/auto-email.js
@@ -1,6 +1,6 @@
 (function( $ ){
 
-  $.fn.autoEmail = function( domain ) {
+  $.fn.autoEmail = function( domain, multi ) {
 
     return this.each(function() {
 
@@ -15,7 +15,7 @@
           //add comma and space after enter is pressed
           var emails = $(this).val().trim().split(/,\s*|;\s*/);
           var email = emails[emails.length-1];
-          if ($this.val().length > 0 && $this.val().trim()[$this.val().trim().length-1] != "," && email.match(/.+@.+\..+/)) {
+          if (multi && $this.val().length > 0 && $this.val().trim()[$this.val().trim().length-1] != "," && email.match(/.+@.+\..+/)) {
             if (keyCode == 59) {
               $this.val($this.val()+"; ");
             } else {


### PR DESCRIPTION
Per @peterfarrell,

> Added the ability to turn off/on the ability to have multiple emails separated by a , or ;. In my case, some of our email fields only allow one email address and allowing the enter key to append a 2nd or more address isn't good.

Just moved the changes to a non-master, pushable branch so I could clean up the README and add a manifest for versioning.
