### PR TITLE
start auto complete after first domain character is typed

### DIFF
--- a/auto-email.js
+++ b/auto-email.js
@@ -1,6 +1,6 @@
 (function( $ ){
 
-  $.fn.autoEmail = function( domains, multi ) {
+  $.fn.autoEmail = function( domains, multi, startAutoCompleteAfterFirstDomainCharacterIsTyped ) {
 
     return this.each(function() {
 
@@ -67,6 +67,9 @@
         // get substring to try appending with autocomplete email
         var emailsDirty = $(this).val().substr(0, selStart).split("@");
         if (emailsDirty.length < 2 || emailsDirty[0] == "") {
+          return;
+        }
+        if (startAutoCompleteAfterFirstDomainCharacterIsTyped && emailsDirty[1] == "") {
           return;
         }
         var emailDomain = emailsDirty[emailsDirty.length - 1];


### PR DESCRIPTION
Hi,

Now the auto complete starts immediately, even if no domain has been typed. That's kinda confusing for some users.

I fixed it in a pull-request. It currently works using an extra parameter, but I guess you could make it standard.
